### PR TITLE
Use `sonatype/public` repo as default fallback

### DIFF
--- a/src/main/scala/com/owlandrews/sbt/thanks/MavenRepositories.scala
+++ b/src/main/scala/com/owlandrews/sbt/thanks/MavenRepositories.scala
@@ -37,5 +37,5 @@ class MavenRepositories(resolvers: Seq[Resolver]) {
   }.flatten
 
   def public: MavenRepository =
-    all.find(_.name == "public").getOrElse(throw new IllegalStateException("No public maven repository defined"))
+    all.find(_.name == "public").getOrElse(Resolver.sonatypeRepo("public"))
 }


### PR DESCRIPTION
#### What
Use `Resolver.sonatypeRepo("public")` when there is no "public" repo is defined.

#### Why
Making the plugin just work by default could make an inexperienced user's life easier. 